### PR TITLE
Auto-activate WeModPRO for all users

### DIFF
--- a/WandEnhancer/View/Popups/PatchVectorsPopup.xaml
+++ b/WandEnhancer/View/Popups/PatchVectorsPopup.xaml
@@ -27,8 +27,7 @@
             </Grid.ColumnDefinitions>
 
             <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="{DynamicResource pv_activate_pro}" />
-            <CheckBox Grid.Row="0" Grid.Column="1" x:Name="ActivateProBox" HorizontalAlignment="Right" VerticalAlignment="Center"
-                      IsChecked="True" />
+            <TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center" Text="✓ Always Active" Foreground="{DynamicResource MutedForeground}" FontSize="12" />
 
             <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="{DynamicResource pv_devtools}" />
             <CheckBox Grid.Row="1" Grid.Column="1" x:Name="DevToolsHotkeyBox" HorizontalAlignment="Right" VerticalAlignment="Center" />

--- a/WandEnhancer/View/Popups/PatchVectorsPopup.xaml.cs
+++ b/WandEnhancer/View/Popups/PatchVectorsPopup.xaml.cs
@@ -68,17 +68,17 @@ namespace WandEnhancer.View.Popups
 
         private void OnPatchButtonClick(object sender, RoutedEventArgs e)
         {
-            if (ActivateProBox.IsChecked != true && DisableUpdateBox.IsChecked != true &&
+            if (DisableUpdateBox.IsChecked != true &&
                 DevToolsHotkeyBox.IsChecked != true && RemoteWebPanelPreviewBox.IsChecked != true)
             {
-                return;
+                // ActivatePro is always applied, so we can proceed with just that
+                // if no other patches are selected
             }
             
             var result = new HashSet<EPatchType>();
-            if (ActivateProBox.IsChecked == true)
-            {
-                result.Add(EPatchType.ActivatePro);
-            }
+            
+            // Always activate Pro
+            result.Add(EPatchType.ActivatePro);
 
             if (DisableUpdateBox.IsChecked == true)
             {


### PR DESCRIPTION
## Motivation

WeModPRO features should be available to all users by default without requiring manual checkbox selection. This change eliminates the optional checkbox and ensures Pro activation is always applied when patching WeMod.

## Changes

- **Always include Pro activation**: Modified `OnPatchButtonClick()` to unconditionally add `EPatchType.ActivatePro` to the patch types
- **Updated UI**: Replaced the interactive checkbox with a static "✓ Always Active" indicator to clearly show that Pro is always enabled
- **Simplified logic**: Removed the condition that checked `ActivateProBox.IsChecked` since Pro is now mandatory

## Technical Details

The Pro patch works by injecting `subscription:{period:"yearly",state:"active"}` into account service responses through four patching vectors:
1. `getUserAccount()` - Account fetch response
2. `setAccountWandBrandExperience()` - Brand experience settings
3. `setAccountLanguage()` - Language change response
4. `setAccountReducer()` - Persistent state updates

Pro status is determined by the presence of the subscription object in the account data.

## User Experience

- Users can no longer disable Pro activation
- Pro features are guaranteed to be available in every patched instance
- The UI clearly indicates that Pro is always active instead of showing an optional checkbox