### PR TITLE
Fix issues #166, #168, #170 and DisableTelemetry KeyNotFoundException

### DIFF
--- a/AsarSharp/Integrity/IntegrityHelper.cs
+++ b/AsarSharp/Integrity/IntegrityHelper.cs
@@ -58,12 +58,26 @@ namespace AsarSharp.Integrity
                     ? (int)((fileStream.Length + BLOCK_SIZE - 1) / BLOCK_SIZE)
                     : 0;
                 var blockHashes = new List<string>(estimatedBlockCount);
-                int bytesRead;
 
-                while ((bytesRead = fileStream.Read(reusableBuffer, 0, reusableBuffer.Length)) > 0)
+                // Stream.Read may return fewer bytes than requested at any point, so
+                // reads accumulate into the block buffer and a hash is emitted only
+                // once a full block is present (same rule as StreamingHasher).
+                int fill = 0;
+                int bytesRead;
+                while ((bytesRead = fileStream.Read(reusableBuffer, fill, reusableBuffer.Length - fill)) > 0)
                 {
-                    blockHashes.Add(ToLowerHex(blockHash.ComputeHash(reusableBuffer, 0, bytesRead)));
-                    fileHash.AppendData(reusableBuffer, 0, bytesRead);
+                    fileHash.AppendData(reusableBuffer, fill, bytesRead);
+                    fill += bytesRead;
+                    if (fill == reusableBuffer.Length)
+                    {
+                        blockHashes.Add(ToLowerHex(blockHash.ComputeHash(reusableBuffer, 0, fill)));
+                        fill = 0;
+                    }
+                }
+
+                if (fill > 0)
+                {
+                    blockHashes.Add(ToLowerHex(blockHash.ComputeHash(reusableBuffer, 0, fill)));
                 }
 
                 return new FileIntegrity

--- a/WandEnhancer/Core/EnhancerConfig.cs
+++ b/WandEnhancer/Core/EnhancerConfig.cs
@@ -201,6 +201,20 @@ namespace WandEnhancer.Core
                     }
                 },
                 {
+                    EPatchType.DisableTelemetry,
+                    new[]
+                    {
+                        // Placeholder entry for DisableTelemetry - currently no telemetry patches implemented
+                        new PatchEntry
+                        {
+                            Name = "telemetryDisabled",
+                            SearchHints = new[] { },
+                            Target = new Regex(@"(?!.*)", RegexOptions.Singleline), // Never matches - patch not yet implemented
+                            Patch = ""
+                        }
+                    }
+                },
+                {
                     EPatchType.DevToolsOnF12,
                     new[]
                     {

--- a/web-panel/bridge/scripts/default/installed-apps-sync/installed-data.js
+++ b/web-panel/bridge/scripts/default/installed-apps-sync/installed-data.js
@@ -22,7 +22,7 @@ import {
 export function resolveInstalledData(state) {
   const storeState = getStoreState(state.storeRef)
 
-  if (isRecord(state.installedAppsService?.installedApps)) {
+  if (isRecord(state.installedAppsService?.installedApps) && Object.keys(state.installedAppsService.installedApps).length > 0) {
     return {
       rawInstalledApps: state.installedAppsService.installedApps,
       catalog: isRecord(state.installedAppsService.catalog)
@@ -561,17 +561,16 @@ function pickImageUrlForTitle(title, game, preferredApp, sidebarClientIconUrl, v
     : [title, game, preferredApp]
 
   return pickImageUrl(
+    getSteamClientIconUrl(
+      findSteamAppId(...steamRoots),
+      getInstalledAppSteamAppId(preferredApp.platform, preferredApp.sku)
+    ),
     title?.imageUrl,
     title?.iconUrl,
     title?.coverUrl,
     title?.thumbnailUrl,
     title?.logoUrl,
     title?.headerImageUrl,
-    getSteamClientIconUrl(
-      findSteamAppId(...steamRoots),
-      getInstalledAppSteamAppId(preferredApp.platform, preferredApp.sku)
-    ),
-    sidebarClientIconUrl,
     title?.images,
     title?.assets,
     game.imageUrl,
@@ -582,6 +581,7 @@ function pickImageUrlForTitle(title, game, preferredApp, sidebarClientIconUrl, v
     game.headerImageUrl,
     game.images,
     game.assets,
-    preferredApp.imageUrl
+    preferredApp.imageUrl,
+    sidebarClientIconUrl
   )
 }

--- a/web-panel/bridge/scripts/default/remote-popup-cleanup.js
+++ b/web-panel/bridge/scripts/default/remote-popup-cleanup.js
@@ -100,9 +100,14 @@ import { resolveQrRenderer as findWandQrRenderer } from "./remote-popup-cleanup/
       return
     }
 
+    const linkText = remoteUrl.replace(/\/$/, "")
     for (const anchor of document.querySelectorAll("remote-tooltip a[href]")) {
-      anchor.setAttribute("href", remoteUrl)
-      anchor.textContent = remoteUrl.replace(/\/$/, "")
+      if (anchor.getAttribute("href") !== remoteUrl) {
+        anchor.setAttribute("href", remoteUrl)
+      }
+      if (anchor.textContent !== linkText) {
+        anchor.textContent = linkText
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes four reported/latent defects found while investigating the open bug reports (Wand not opening after patching, #214/#213/#211/#210):

## Changes

### 1. AsarSharp: invalid `integrity.blocks` on short reads — fixes #170
`IntegrityHelper.GetFileIntegrity` assumed every `Stream.Read` returns a full block. Reads now accumulate into the block buffer and a hash is emitted only once a full block is present (the same rule `StreamingHasher.Append`/`Finalise` already applies), with the remainder flushed after the loop.

Verified with a port of the exact algorithm: for always-full, 1-byte, ragged, and short-mid-file read patterns the emitted blocks now always match the StreamingHasher reference and align on `BLOCK_SIZE` boundaries (previously, 1-byte reads produced one hash per byte — e.g. 15000 blocks instead of 4 for a 15KB file). Exact-multiple-of-block, empty-file, and sub-block-file edge cases all pass.

### 2. remote-popup-cleanup: self-feeding MutationObserver — fixes #168
`updateLinks` wrote `textContent` unconditionally; assigning `textContent` always emits a `childList` mutation, so the observer re-triggered its own refresh once per macrotask while a `remote-tooltip` was open. Both `href` and `textContent` writes are now guarded with equality checks, mirroring the existing `updateQrCodes` guard.

### 3. installed-apps-sync: Steam `client_icon` never preferred + empty service slice — fixes #166
- `pickImageUrlForTitle` now tries the Steam `client_icon` CDN URL **first** (it returns `null` when no AppID resolves, so non-Steam titles fall through unchanged), per the AGENTS.md rule, and the scraped sidebar DOM URL moved to **last** fallback instead of overriding game metadata.
- `resolveInstalledData` now requires a **non-empty** service `installedApps` record before bypassing the store fallback, so a freshly-resolved-but-empty service no longer shadows a hydrated store (the warn message at `buildSnapshot` already anticipated this case).

### 4. EnhancerConfig: `DisableTelemetry` KeyNotFoundException — fixes #172
`EPatchType.DisableTelemetry` has no entry in `EnhancerConfig.GetInstance()`. Since `PatchAsar` unconditionally indexes `enhancerConfig[entry]` for every selected patch type, selecting DisableTelemetry (value 4, mask-compatible) would throw. A placeholder entry with a never-matching regex keeps the lookup total; it applies no code changes.

## Validation

- `node --check` (ESM) passes for both modified renderer scripts.
- Integrity algorithm simulated against the StreamingHasher reference across all read patterns — all pass (see #1).
- C# build not runnable in this environment (no MSBuild); changes follow existing code patterns in the same files.